### PR TITLE
Update to version 6.61

### DIFF
--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -60,8 +60,8 @@ modules:
       - desktop-file-validate /app/share/applications/${FLATPAK_ID}.desktop
     sources:
       - type: archive
-        url: https://www.reaper.fm/files/6.x/reaper658_linux_x86_64.tar.xz
-        sha256: 8d18e110a75f99640161c852acf3610dfeb2a2712a49df2012888236e89dcac3
+        url: https://www.reaper.fm/files/6.x/reaper661_linux_x86_64.tar.xz
+        sha256: 2e9d84564cb5fabb9cf3a2dd326be16488aca189743b176456737787fbb4f484
       - type: file
         path: fm.reaper.Reaper.desktop
       - type: file


### PR DESCRIPTION
Tested to work on Alpine Linux (which has a musl-related segfault when saving with a traditional installation)